### PR TITLE
Fixed hash codes for double values in entities.

### DIFF
--- a/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/implementation/HashCodeExecutableBuilder.java
+++ b/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/implementation/HashCodeExecutableBuilder.java
@@ -95,7 +95,7 @@ class HashCodeExecutableBuilder extends ExecutableBuilder {
                     block.append(new LongToIntegerHashConversion(temp));
                 }
             };
-            return new HashCodeValue(setup, value);
+            return new HashCodeStatement(setup, value);
         }
 
         if (Utils.isSameType(type, boolean.class)) {
@@ -146,7 +146,7 @@ class HashCodeExecutableBuilder extends ExecutableBuilder {
     private static class HashCodeStatement {
     
         private final CodeElement mSetup;
-        private final CodeElement mHashCodeValue:
+        private final CodeElement mHashCodeValue;
         
         public HashCodeStatement(CodeElement setup, CodeElement hashCodeValue) {
             mSetup = setup;


### PR DESCRIPTION
Hash codes are now calculated correctly for primitive double values in json entities.

This fixes an issue which caused the generated code to not compile as soon as primitive double values were used.