### PR TITLE
Added Builder class to generated Factory classes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,15 @@ Each factory class also has a `create()` method which can be used to create new 
 ExampleModel model = ExampleModels.create(27L, "text");
 ```
 
+Alternatively you can create instances of your models using the `Builder` classes which are also generated along with the factory classes:
+
+```java
+ExampleModel model = new ExampleModels.Builder()
+        .setId(27L)
+        .setText("text")
+        .build();
+```
+
 ## Optional fields
 
 If there is an optional element in a JSON you want to parse just annotate the corrosponding getter with `@Optional`. If the element is missing from the json then it will be parsed as `null`. If an element is not annotated with `@Optional` and it is missing from the JSON than a `SimpleJsonException` will be thrown! 

--- a/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/ParserBuilder.java
+++ b/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/ParserBuilder.java
@@ -4,7 +4,6 @@ import com.github.wrdlbrnft.codebuilder.code.SourceFile;
 import com.github.wrdlbrnft.codebuilder.implementations.Implementation;
 import com.github.wrdlbrnft.codebuilder.types.Type;
 import com.github.wrdlbrnft.codebuilder.util.Utils;
-import com.github.wrdlbrnft.simplejson.builder.builder.BuilderBuilder;
 import com.github.wrdlbrnft.simplejson.builder.enums.EnumParserBuilder;
 import com.github.wrdlbrnft.simplejson.builder.factories.entity.JsonEntityFactoryBuilder;
 import com.github.wrdlbrnft.simplejson.builder.factories.enums.EnumFactoryBuilder;

--- a/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/ParserBuilder.java
+++ b/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/ParserBuilder.java
@@ -4,6 +4,7 @@ import com.github.wrdlbrnft.codebuilder.code.SourceFile;
 import com.github.wrdlbrnft.codebuilder.implementations.Implementation;
 import com.github.wrdlbrnft.codebuilder.types.Type;
 import com.github.wrdlbrnft.codebuilder.util.Utils;
+import com.github.wrdlbrnft.simplejson.builder.builder.BuilderBuilder;
 import com.github.wrdlbrnft.simplejson.builder.enums.EnumParserBuilder;
 import com.github.wrdlbrnft.simplejson.builder.factories.entity.JsonEntityFactoryBuilder;
 import com.github.wrdlbrnft.simplejson.builder.factories.enums.EnumFactoryBuilder;

--- a/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/builder/BuilderBuilder.java
+++ b/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/builder/BuilderBuilder.java
@@ -1,0 +1,153 @@
+package com.github.wrdlbrnft.simplejson.builder.builder;
+
+import com.github.wrdlbrnft.codebuilder.code.Block;
+import com.github.wrdlbrnft.codebuilder.code.CodeBuilder;
+import com.github.wrdlbrnft.codebuilder.code.CodeElement;
+import com.github.wrdlbrnft.codebuilder.code.NameGenerator;
+import com.github.wrdlbrnft.codebuilder.code.Resolver;
+import com.github.wrdlbrnft.codebuilder.elements.values.Values;
+import com.github.wrdlbrnft.codebuilder.executables.ExecutableBuilder;
+import com.github.wrdlbrnft.codebuilder.executables.Method;
+import com.github.wrdlbrnft.codebuilder.implementations.Implementation;
+import com.github.wrdlbrnft.codebuilder.types.Type;
+import com.github.wrdlbrnft.codebuilder.types.Types;
+import com.github.wrdlbrnft.codebuilder.variables.Field;
+import com.github.wrdlbrnft.codebuilder.variables.Variable;
+import com.github.wrdlbrnft.simplejson.builder.implementation.MethodPairInfo;
+import com.github.wrdlbrnft.simplejson.models.ImplementationResult;
+import com.github.wrdlbrnft.simplejson.models.MappedValue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+
+import javax.lang.model.element.Modifier;
+import javax.lang.model.type.TypeMirror;
+
+/**
+ * Created with Android Studio<br>
+ * User: Xaver<br>
+ * Date: 04/02/2018
+ */
+
+public class BuilderBuilder {
+
+    private static final List<String> PARAMETER_NAME_BLACK_LIST = Arrays.asList(
+            "int",
+            "long",
+            "float",
+            "double",
+            "boolean"
+    );
+
+    public Implementation build(ImplementationResult result) {
+        final Implementation.Builder builder = new Implementation.Builder()
+                .setModifiers(EnumSet.of(Modifier.PUBLIC, Modifier.STATIC))
+                .setName("Builder");
+
+        final TypeStub builderType = new TypeStub();
+
+        final List<CodeElement> fields = new ArrayList<>();
+
+        for (MappedValue mappedValue : result.getMappedValues()) {
+            final MethodPairInfo info = mappedValue.getMethodPairInfo();
+            final TypeMirror typeMirror = info.getGetter().getReturnType();
+
+            final Variable parameter = new Variable.Builder()
+                    .setName(formatAsParameterName(info.getGroupName()))
+                    .setType(Types.of(typeMirror))
+                    .build();
+
+            final Field field = new Field.Builder()
+                    .setType(Types.of(typeMirror))
+                    .setModifiers(EnumSet.of(Modifier.PRIVATE))
+                    .build();
+            fields.add(field);
+
+            builder.addField(field);
+            builder.addMethod(new Method.Builder()
+                    .setName("set" + info.getGroupName())
+                    .setModifiers(EnumSet.of(Modifier.PUBLIC))
+                    .setReturnType(builderType)
+                    .setCode(new ExecutableBuilder() {
+                        @Override
+                        protected List<Variable> createParameters() {
+                            return Collections.singletonList(parameter);
+                        }
+
+                        @Override
+                        protected void write(Block block) {
+                            block.set(field, parameter).append(";").newLine();
+                            block.append("return ").append(Values.ofThis()).append(";");
+                        }
+                    })
+                    .build());
+        }
+
+        builder.addMethod(new Method.Builder()
+                .setName("build")
+                .setModifiers(EnumSet.of(Modifier.PUBLIC))
+                .setReturnType(Types.of(result.getInterfaceType()))
+                .setCode(new ExecutableBuilder() {
+                    @Override
+                    protected List<Variable> createParameters() {
+                        return Collections.emptyList();
+                    }
+
+                    @Override
+                    protected void write(Block block) {
+                        final CodeElement instance = result.getImplType().newInstance(fields.toArray(new CodeElement[fields.size()]));
+                        block.append("return ").append(instance).append(";");
+                    }
+                })
+                .build());
+
+        final Implementation implementation = builder.build();
+        builderType.setType(implementation);
+        return implementation;
+    }
+
+    private String formatAsParameterName(String groupName) {
+        final String name = groupName.substring(0, 1).toLowerCase() + groupName.substring(1);
+        if (PARAMETER_NAME_BLACK_LIST.contains(name)) {
+            return "_" + name;
+        }
+        return name;
+    }
+
+    private static class TypeStub implements Type {
+
+        private Type mType;
+
+        public void setType(Type type) {
+            mType = type;
+        }
+
+        @Override
+        public CodeElement newInstance(CodeElement... codeElements) {
+            return mType.newInstance(codeElements);
+        }
+
+        @Override
+        public CodeElement classObject() {
+            return mType.classObject();
+        }
+
+        @Override
+        public void prepare() {
+            mType.prepare();
+        }
+
+        @Override
+        public void resolve(Resolver resolver, NameGenerator nameGenerator) {
+            mType.resolve(resolver, nameGenerator);
+        }
+
+        @Override
+        public void write(CodeBuilder codeBuilder) {
+            mType.write(codeBuilder);
+        }
+    }
+}

--- a/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/factories/entity/FactoryMethodBuilder.java
+++ b/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/factories/entity/FactoryMethodBuilder.java
@@ -9,6 +9,7 @@ import com.github.wrdlbrnft.simplejson.builder.implementation.MethodPairInfo;
 import com.github.wrdlbrnft.simplejson.models.MappedValue;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import javax.lang.model.type.TypeMirror;
@@ -17,6 +18,14 @@ import javax.lang.model.type.TypeMirror;
  * Created by kapeller on 09/07/15.
  */
 class FactoryMethodBuilder extends ExecutableBuilder {
+
+    private static final List<String> PARAMETER_NAME_BLACK_LIST = Arrays.asList(
+            "int",
+            "long",
+            "float",
+            "double",
+            "boolean"
+    );
 
     private final List<MappedValue> mMappedValues;
     private final Type mImplementationType;
@@ -55,6 +64,10 @@ class FactoryMethodBuilder extends ExecutableBuilder {
     }
 
     private String formatAsParameterName(String groupName) {
-        return groupName.substring(0, 1).toLowerCase() + groupName.substring(1);
+        final String name = groupName.substring(0, 1).toLowerCase() + groupName.substring(1);
+        if (PARAMETER_NAME_BLACK_LIST.contains(name)) {
+            return "_" + name;
+        }
+        return name;
     }
 }

--- a/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/factories/entity/JsonEntityFactoryBuilder.java
+++ b/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/factories/entity/JsonEntityFactoryBuilder.java
@@ -13,13 +13,13 @@ import com.github.wrdlbrnft.codebuilder.variables.Variables;
 import com.github.wrdlbrnft.simplejson.SimpleJsonAnnotations;
 import com.github.wrdlbrnft.simplejson.SimpleJsonTypes;
 import com.github.wrdlbrnft.simplejson.builder.ParserBuilder;
+import com.github.wrdlbrnft.simplejson.builder.builder.BuilderBuilder;
 import com.github.wrdlbrnft.simplejson.builder.implementation.ImplementationBuilder;
 import com.github.wrdlbrnft.simplejson.builder.parser.InternalParserBuilder;
 import com.github.wrdlbrnft.simplejson.models.ImplementationResult;
 import com.github.wrdlbrnft.simplejson.models.MappedValue;
 
 import java.util.ArrayList;
-import java.util.BitSet;
 import java.util.EnumSet;
 import java.util.List;
 
@@ -35,11 +35,13 @@ public class JsonEntityFactoryBuilder {
     private final ParserBuilder.BuildCache mBuildCache;
     private final ImplementationBuilder mImplementationBuilder;
     private final InternalParserBuilder mInternalParserBuilder;
+    private final BuilderBuilder mBuilderBuilder;
 
     public JsonEntityFactoryBuilder(ParserBuilder.BuildCache buildCache, ImplementationBuilder implementationBuilder, InternalParserBuilder internalParserBuilder) {
         mBuildCache = buildCache;
         mImplementationBuilder = implementationBuilder;
         mInternalParserBuilder = internalParserBuilder;
+        mBuilderBuilder = new BuilderBuilder();
     }
 
     public Implementation build(TypeElement interfaceElement) {
@@ -49,6 +51,10 @@ public class JsonEntityFactoryBuilder {
 
         final ImplementationResult result = mImplementationBuilder.build(interfaceElement);
         builder.addNestedImplementation(result.getImplType());
+
+        final Implementation builderImplementation = mBuilderBuilder.build(result);
+        builder.addNestedImplementation(builderImplementation);
+
         final Implementation parserType = mInternalParserBuilder.build(interfaceElement, result);
         builder.addNestedImplementation(parserType);
 
@@ -182,9 +188,12 @@ public class JsonEntityFactoryBuilder {
             }
         }
 
+
         final String typeName = Utils.getClassName(element);
         if (Character.toLowerCase(typeName.charAt(typeName.length() - 1)) == 's') {
             return typeName + "Factory";
+        } else if (Character.toLowerCase(typeName.charAt(typeName.length() - 1)) == 'y') {
+            return typeName.substring(0, typeName.length() - 1) + "ies";
         }
         return typeName + "s";
     }

--- a/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/parser/EntityFormater.java
+++ b/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/parser/EntityFormater.java
@@ -13,6 +13,7 @@ import com.github.wrdlbrnft.simplejson.builder.implementation.MethodPairInfo;
 import com.github.wrdlbrnft.simplejson.builder.parser.resolver.ElementParserResolver;
 import com.github.wrdlbrnft.simplejson.models.MappedValue;
 
+import javax.lang.model.element.Modifier;
 import javax.lang.model.type.TypeMirror;
 
 /**
@@ -50,7 +51,7 @@ class EntityFormater {
         final MethodPairInfo info = mappedValue.getMethodPairInfo();
         final TypeMirror type = mappedValue.getItemType();
         final Field parser = mParserResolver.getElementParserField(mappedValue);
-        final Variable varJsonArray = Variables.of(SimpleJsonTypes.JSON_ARRAY);
+        final Variable varJsonArray = Variables.of(SimpleJsonTypes.JSON_ARRAY, Modifier.FINAL);
         block.set(varJsonArray, SimpleJsonTypes.JSON_ARRAY.newInstance()).append(";").newLine();
 
         block.append(new Foreach.Builder()

--- a/docs/index.md
+++ b/docs/index.md
@@ -86,6 +86,15 @@ Each factory class also has a `create()` method which can be used to create new 
 ExampleModel model = ExampleModels.create(27L, "text");
 ```
 
+Alternatively you can create instances of your models using the `Builder` classes which are also generated along with the factory classes:
+
+```java
+ExampleModel model = new ExampleModels.Builder()
+        .setId(27L)
+        .setText("text")
+        .build();
+```
+
 ## Optional fields
 
 If there is an optional element in a JSON you want to parse just annotate the corrosponding getter with `@Optional`. If the element is missing from the json then it will be parsed as `null`. If an element is not annotated with `@Optional` and it is missing from the JSON than a `SimpleJsonException` will be thrown! 


### PR DESCRIPTION
All generated factory classes will now also contain a Builder class which lets one construct a JsonEntity like this:

Model used in this example:
```java
@JsonEntity
public interface ExampleModel {

    @FieldName("amount")
    int getAmount();

    @FieldName("text")
    String getText();
}
```

The Builder class generated for this model can be used like this:

```java
final ExampleModel model = new ExampleModels.Builder()
        .setAmount(1234)
        .setText("asdf asdf")
        .build();
```
