### PR TITLE
Fixing custom parser class resolution.

### DIFF
--- a/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/parser/resolver/CustomParserEntry.java
+++ b/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/parser/resolver/CustomParserEntry.java
@@ -6,9 +6,12 @@ import com.github.wrdlbrnft.codebuilder.variables.Field;
 import com.github.wrdlbrnft.simplejson.SimpleJsonTypes;
 import com.github.wrdlbrnft.simplejson.builder.ParserBuilder;
 import com.github.wrdlbrnft.simplejson.models.MappedValue;
+import com.github.wrdlbrnft.simplejson.SimpleJsonAnnotations;
+import com.github.wrdlbrnft.simplejson.builder.implementation.MethodPairInfo;
 
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.type.TypeMirror;
+import javax.lang.model.element.AnnotationValue;
 
 /**
  * Created with Android Studio<br>

--- a/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/parser/resolver/CustomParserEntry.java
+++ b/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/parser/resolver/CustomParserEntry.java
@@ -1,0 +1,48 @@
+package com.github.wrdlbrnft.simplejson.builder.parser.resolver;
+
+import com.github.wrdlbrnft.codebuilder.types.Types;
+import com.github.wrdlbrnft.codebuilder.util.Utils;
+import com.github.wrdlbrnft.codebuilder.variables.Field;
+import com.github.wrdlbrnft.simplejson.SimpleJsonTypes;
+import com.github.wrdlbrnft.simplejson.builder.ParserBuilder;
+import com.github.wrdlbrnft.simplejson.models.MappedValue;
+
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.type.TypeMirror;
+
+/**
+ * Created with Android Studio<br>
+ * User: Xaver<br>
+ * Date: 03/02/2018
+ */
+
+class CustomParserEntry extends BaseParserEntry {
+
+    CustomParserEntry(ProcessingEnvironment processingEnvironment, ParserBuilder.BuildCache buildCache) {
+        super(processingEnvironment, buildCache);
+    }
+
+    @Override
+    protected boolean matches(MappedValue value, TypeMirror type) {
+        final MethodPairInfo methodPairInfo = value.getMethodPairInfo();
+        final AnnotationValue parserClassValue = methodPairInfo.findAnnotationValue(SimpleJsonAnnotations.FIELD_NAME, "parserClass");
+        return parserClassValue != null;
+    }
+
+    @Override
+    protected String getKey(MappedValue value, TypeMirror type) {
+        final MethodPairInfo methodPairInfo = value.getMethodPairInfo();
+        final AnnotationValue parserClassValue = methodPairInfo.findAnnotationValue(SimpleJsonAnnotations.FIELD_NAME, "parserClass");
+        return "_custom_" + parserClassValue.getValue();
+    }
+
+    @Override
+    protected Field createField(MappedValue value, TypeMirror type) {
+        final MethodPairInfo methodPairInfo = value.getMethodPairInfo();
+        final AnnotationValue parserClassValue = methodPairInfo.findAnnotationValue(SimpleJsonAnnotations.FIELD_NAME, "parserClass");
+        return createElementParserField(
+                Types.generic(SimpleJsonTypes.ELEMENT_PARSER, Types.of(type)),
+                Types.of(parserTypeMirror)
+        );
+    }
+}

--- a/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/parser/resolver/CustomParserEntry.java
+++ b/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/parser/resolver/CustomParserEntry.java
@@ -43,6 +43,7 @@ class CustomParserEntry extends BaseParserEntry {
     protected Field createField(MappedValue value, TypeMirror type) {
         final MethodPairInfo methodPairInfo = value.getMethodPairInfo();
         final AnnotationValue parserClassValue = methodPairInfo.findAnnotationValue(SimpleJsonAnnotations.FIELD_NAME, "parserClass");
+        final TypeMirror parserTypeMirror = (TypeMirror) parserClassValue.getValue();
         return createElementParserField(
                 Types.generic(SimpleJsonTypes.ELEMENT_PARSER, Types.of(type)),
                 Types.of(parserTypeMirror)

--- a/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/parser/resolver/ElementParserResolver.java
+++ b/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/parser/resolver/ElementParserResolver.java
@@ -54,6 +54,7 @@ public class ElementParserResolver {
                 new CalendarParserEntry(mProcessingEnvironment, mBuildCache),
                 new DateParserEntry(mProcessingEnvironment, mBuildCache),
                 new DoubleParserEntry(mProcessingEnvironment, mBuildCache),
+                new CustomParserEntry(mProcessingEnvironment, mBuildCache),
                 new EnumParserEntry(mProcessingEnvironment, mBuildCache),
                 new FloatParserEntry(mProcessingEnvironment, mBuildCache),
                 new IntegerParserEntry(mProcessingEnvironment, mBuildCache),

--- a/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/parser/resolver/ElementParserResolver.java
+++ b/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/parser/resolver/ElementParserResolver.java
@@ -85,6 +85,7 @@ public class ElementParserResolver {
                     mFields.add(field);
                     return field;
                 })
+                .map(CodeElement.class::cast)
                 .orElseGet(() -> {
                     mProcessingEnvironment.getMessager().printMessage(Diagnostic.Kind.ERROR, "Failed to find a parser for " + type, mappedValue.getMethodPairInfo().getGetter());
                     return Values.ofNull();

--- a/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/parser/resolver/ElementParserResolver.java
+++ b/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/parser/resolver/ElementParserResolver.java
@@ -85,27 +85,8 @@ public class ElementParserResolver {
                     return field;
                 })
                 .orElseGet(() -> {
-                    final MethodPairInfo methodPairInfo = mappedValue.getMethodPairInfo();
-                    final AnnotationValue parserClassValue = methodPairInfo.findAnnotationValue(SimpleJsonAnnotations.FIELD_NAME, "parserClass");
-                    if (parserClassValue != null) {
-                        final TypeMirror parserTypeMirror = (TypeMirror) parserClassValue.getValue();
-                        return createElementParserField(
-                                Types.generic(SimpleJsonTypes.ELEMENT_PARSER, Types.of(type)),
-                                Types.of(parserTypeMirror)
-                        );
-                    } else {
-
-                        final Type parser = mBuildCache.getCustomParser(element);
-                        if (parser == null) {
-                            mProcessingEnvironment.getMessager().printMessage(Diagnostic.Kind.ERROR, "Could not find a parser for " + element.getSimpleName() + "!!1 Have you forgot to annotate it? If the class is a framework class then most likely it is not supported to be used in entities created with this library.", mInterfaceType);
-                            return null;
-                        }
-
-                        return createElementParserField(
-                                Types.generic(SimpleJsonTypes.ELEMENT_PARSER, Types.of(type)),
-                                parser
-                        );
-                    }
+                    mProcessingEnvironment.getMessager().printMessage(Diagnostic.Kind.ERROR, "Failed to find a parser for " + type, mappedValue.getMethodPairInfo().getGetter());
+                    return Values.ofNull();
                 });
     }
 


### PR DESCRIPTION
There is a bug in the resolution of custom parser classes.

The parser fields are not added to the parser classes which causes SimpleJson to generate invalid code once custom parser classes are used. 

This pull request fixes that error.