### PR TITLE
Strict mode can now be switched on and off.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ The next generation JSON Parser for Android!
 Just add is these two dependencies to your build.gradle file:
 
 ```groovy
-implementation 'com.github.wrdlbrnft:simple-json:0.3.0.35'
-annotationProcessor 'com.github.wrdlbrnft:simple-json-processor:0.3.0.35'
+implementation 'com.github.wrdlbrnft:simple-json:0.3.0.53'
+annotationProcessor 'com.github.wrdlbrnft:simple-json-processor:0.3.0.53'
 ```
 
 ## Basic Usage

--- a/SimpleJson/src/main/java/com/github/wrdlbrnft/simplejson/annotations/JsonEntity.java
+++ b/SimpleJson/src/main/java/com/github/wrdlbrnft/simplejson/annotations/JsonEntity.java
@@ -12,4 +12,5 @@ import java.lang.annotation.Target;
 @Target(ElementType.TYPE)
 public @interface JsonEntity {
     String factoryName() default "";
+    boolean strict() default false;
 }

--- a/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/SimpleJsonProcessor.java
+++ b/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/SimpleJsonProcessor.java
@@ -17,12 +17,15 @@ import java.util.logging.Logger;
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedSourceVersion;
+import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeMirror;
 import javax.tools.Diagnostic;
 
+@SupportedSourceVersion(SourceVersion.RELEASE_8)
 public class SimpleJsonProcessor extends AbstractProcessor {
     private static final String ELEMENT_PARSER_TYPE_NAME = "com.github.wrdlbrnft.simplejson.parsers.ElementParser";
 

--- a/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/ParserBuilder.java
+++ b/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/ParserBuilder.java
@@ -9,7 +9,7 @@ import com.github.wrdlbrnft.simplejson.builder.factories.entity.JsonEntityFactor
 import com.github.wrdlbrnft.simplejson.builder.factories.enums.EnumFactoryBuilder;
 import com.github.wrdlbrnft.simplejson.builder.implementation.ImplementationBuilder;
 import com.github.wrdlbrnft.simplejson.builder.parser.InternalParserBuilder;
-import com.github.wrdlbrnft.simplejson.models.ImplementationResult;
+import com.github.wrdlbrnft.simplejson.builder.implementation.ImplementationResult;
 import com.github.wrdlbrnft.simplejson.utils.ImplementationStub;
 
 import java.io.IOException;

--- a/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/builder/BuilderBuilder.java
+++ b/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/builder/BuilderBuilder.java
@@ -9,9 +9,9 @@ import com.github.wrdlbrnft.codebuilder.implementations.Implementation;
 import com.github.wrdlbrnft.codebuilder.types.Types;
 import com.github.wrdlbrnft.codebuilder.variables.Field;
 import com.github.wrdlbrnft.codebuilder.variables.Variable;
+import com.github.wrdlbrnft.simplejson.builder.implementation.ImplementationResult;
+import com.github.wrdlbrnft.simplejson.builder.implementation.MappedValue;
 import com.github.wrdlbrnft.simplejson.builder.implementation.MethodPairInfo;
-import com.github.wrdlbrnft.simplejson.models.ImplementationResult;
-import com.github.wrdlbrnft.simplejson.models.MappedValue;
 import com.github.wrdlbrnft.simplejson.utils.TypeStub;
 
 import java.util.ArrayList;
@@ -56,7 +56,7 @@ public class BuilderBuilder {
                     .setModifiers(EnumSet.of(Modifier.PRIVATE))
                     .build();
 
-            parameters.add(handleOptionalParameter(mappedValue, field));
+            parameters.add(handleOptionalParameter(result.getImplementationInfo(), mappedValue, field));
 
             builder.addField(field);
             builder.addMethod(new Method.Builder()

--- a/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/factories/entity/JsonEntityFactoryBuilder.java
+++ b/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/factories/entity/JsonEntityFactoryBuilder.java
@@ -16,8 +16,8 @@ import com.github.wrdlbrnft.simplejson.builder.ParserBuilder;
 import com.github.wrdlbrnft.simplejson.builder.builder.BuilderBuilder;
 import com.github.wrdlbrnft.simplejson.builder.implementation.ImplementationBuilder;
 import com.github.wrdlbrnft.simplejson.builder.parser.InternalParserBuilder;
-import com.github.wrdlbrnft.simplejson.models.ImplementationResult;
-import com.github.wrdlbrnft.simplejson.models.MappedValue;
+import com.github.wrdlbrnft.simplejson.builder.implementation.ImplementationResult;
+import com.github.wrdlbrnft.simplejson.builder.implementation.MappedValue;
 
 import java.util.ArrayList;
 import java.util.EnumSet;
@@ -67,8 +67,6 @@ public class JsonEntityFactoryBuilder {
         builder.setModifiers(EnumSet.of(Modifier.PUBLIC, Modifier.FINAL));
 
         final TypeElement interfaceType = result.getInterfaceType();
-        final Type implType = result.getImplType();
-        final List<MappedValue> mappedValues = result.getMappedValues();
 
         final Field parserField = new Field.Builder()
                 .setType(Types.generic(SimpleJsonTypes.PARSER, entityType))
@@ -81,7 +79,7 @@ public class JsonEntityFactoryBuilder {
                 .setReturnType(Types.of(interfaceType))
                 .setName("create")
                 .setModifiers(EnumSet.of(Modifier.PUBLIC, Modifier.STATIC))
-                .setCode(new FactoryMethodBuilder(implType, mappedValues))
+                .setCode(new FactoryMethodBuilder(result))
                 .build());
 
         builder.addMethod(new Method.Builder()

--- a/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/implementation/ConstructorBuilder.java
+++ b/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/implementation/ConstructorBuilder.java
@@ -6,7 +6,6 @@ import com.github.wrdlbrnft.codebuilder.types.Types;
 import com.github.wrdlbrnft.codebuilder.variables.Field;
 import com.github.wrdlbrnft.codebuilder.variables.Variable;
 import com.github.wrdlbrnft.codebuilder.variables.Variables;
-import com.github.wrdlbrnft.simplejson.models.MappedValue;
 
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/implementation/EqualsExecutableBuilder.java
+++ b/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/implementation/EqualsExecutableBuilder.java
@@ -17,7 +17,6 @@ import com.github.wrdlbrnft.codebuilder.util.Utils;
 import com.github.wrdlbrnft.codebuilder.variables.Field;
 import com.github.wrdlbrnft.codebuilder.variables.Variable;
 import com.github.wrdlbrnft.codebuilder.variables.Variables;
-import com.github.wrdlbrnft.simplejson.models.MappedValue;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/implementation/HashCodeExecutableBuilder.java
+++ b/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/implementation/HashCodeExecutableBuilder.java
@@ -14,7 +14,6 @@ import com.github.wrdlbrnft.codebuilder.util.Utils;
 import com.github.wrdlbrnft.codebuilder.variables.Field;
 import com.github.wrdlbrnft.codebuilder.variables.Variable;
 import com.github.wrdlbrnft.codebuilder.variables.Variables;
-import com.github.wrdlbrnft.simplejson.models.MappedValue;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/implementation/ImplementationBuilder.java
+++ b/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/implementation/ImplementationBuilder.java
@@ -15,14 +15,13 @@ import com.github.wrdlbrnft.codebuilder.variables.Field;
 import com.github.wrdlbrnft.codebuilder.variables.Variable;
 import com.github.wrdlbrnft.codebuilder.variables.Variables;
 import com.github.wrdlbrnft.simplejson.SimpleJsonAnnotations;
-import com.github.wrdlbrnft.simplejson.models.ImplementationResult;
-import com.github.wrdlbrnft.simplejson.models.MappedValue;
 
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
 
 import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.element.AnnotationValue;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
@@ -91,7 +90,10 @@ public class ImplementationBuilder {
         final Implementation implementation = mBuilder.build();
         lazyImplType.setType(implementation);
 
-        return new ImplementationResult(implementation, model, mappedValues);
+        final AnnotationValue annotationValue = Utils.getAnnotationValue(model, SimpleJsonAnnotations.JSON_ENTITY, "strict");
+        final boolean strictMode = annotationValue != null && (boolean) annotationValue.getValue();
+        final ImplementationInfo implementationInfo = new ImplementationInfo(strictMode);
+        return new ImplementationResult(implementation, model, mappedValues, implementationInfo);
     }
 
     private MappedValue createMappedValueWrapper(TypeElement parent, MethodPairInfo info) {

--- a/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/implementation/ImplementationInfo.java
+++ b/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/implementation/ImplementationInfo.java
@@ -1,0 +1,20 @@
+package com.github.wrdlbrnft.simplejson.builder.implementation;
+
+/**
+ * Created with Android Studio<br>
+ * User: Xaver<br>
+ * Date: 11/02/2018
+ */
+
+public class ImplementationInfo {
+
+    private final boolean mStrict;
+
+    public ImplementationInfo(boolean strict) {
+        mStrict = strict;
+    }
+
+    public boolean isStrict() {
+        return mStrict;
+    }
+}

--- a/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/implementation/ImplementationResult.java
+++ b/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/implementation/ImplementationResult.java
@@ -1,7 +1,6 @@
-package com.github.wrdlbrnft.simplejson.models;
+package com.github.wrdlbrnft.simplejson.builder.implementation;
 
 import com.github.wrdlbrnft.codebuilder.implementations.Implementation;
-import com.github.wrdlbrnft.codebuilder.types.Type;
 
 import java.util.List;
 
@@ -15,11 +14,13 @@ public class ImplementationResult {
     private final TypeElement mInterfaceType;
     private final Implementation mImplType;
     private final List<MappedValue> mMappedValues;
+    private final ImplementationInfo mImplementationInfo;
 
-    public ImplementationResult(Implementation implType, TypeElement interfaceType, List<MappedValue> mappedValues) {
+    public ImplementationResult(Implementation implType, TypeElement interfaceType, List<MappedValue> mappedValues, ImplementationInfo implementationInfo) {
         mInterfaceType = interfaceType;
         mImplType = implType;
         mMappedValues = mappedValues;
+        mImplementationInfo = implementationInfo;
     }
 
     public Implementation getImplType() {
@@ -32,5 +33,9 @@ public class ImplementationResult {
 
     public TypeElement getInterfaceType() {
         return mInterfaceType;
+    }
+
+    public ImplementationInfo getImplementationInfo() {
+        return mImplementationInfo;
     }
 }

--- a/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/implementation/MappedValue.java
+++ b/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/implementation/MappedValue.java
@@ -1,4 +1,4 @@
-package com.github.wrdlbrnft.simplejson.models;
+package com.github.wrdlbrnft.simplejson.builder.implementation;
 
 import com.github.wrdlbrnft.codebuilder.variables.Field;
 import com.github.wrdlbrnft.simplejson.builder.implementation.MethodPairInfo;

--- a/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/parser/EntityFormater.java
+++ b/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/parser/EntityFormater.java
@@ -14,7 +14,7 @@ import com.github.wrdlbrnft.codebuilder.variables.Variables;
 import com.github.wrdlbrnft.simplejson.SimpleJsonTypes;
 import com.github.wrdlbrnft.simplejson.builder.implementation.MethodPairInfo;
 import com.github.wrdlbrnft.simplejson.builder.parser.resolver.ElementParserResolver;
-import com.github.wrdlbrnft.simplejson.models.MappedValue;
+import com.github.wrdlbrnft.simplejson.builder.implementation.MappedValue;
 
 import javax.lang.model.element.Modifier;
 import javax.lang.model.type.TypeMirror;

--- a/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/parser/EntityParser.java
+++ b/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/parser/EntityParser.java
@@ -8,12 +8,11 @@ import com.github.wrdlbrnft.codebuilder.elements.ifs.If;
 import com.github.wrdlbrnft.codebuilder.elements.values.Values;
 import com.github.wrdlbrnft.codebuilder.types.Types;
 import com.github.wrdlbrnft.codebuilder.util.Operators;
-import com.github.wrdlbrnft.codebuilder.variables.Field;
 import com.github.wrdlbrnft.codebuilder.variables.Variable;
 import com.github.wrdlbrnft.codebuilder.variables.Variables;
 import com.github.wrdlbrnft.simplejson.SimpleJsonTypes;
 import com.github.wrdlbrnft.simplejson.builder.parser.resolver.ElementParserResolver;
-import com.github.wrdlbrnft.simplejson.models.MappedValue;
+import com.github.wrdlbrnft.simplejson.builder.implementation.MappedValue;
 
 import javax.lang.model.element.Modifier;
 import javax.lang.model.type.TypeMirror;

--- a/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/parser/FromJsonObjectBuilder.java
+++ b/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/parser/FromJsonObjectBuilder.java
@@ -6,7 +6,7 @@ import com.github.wrdlbrnft.codebuilder.types.Type;
 import com.github.wrdlbrnft.codebuilder.variables.Variable;
 import com.github.wrdlbrnft.codebuilder.variables.Variables;
 import com.github.wrdlbrnft.simplejson.SimpleJsonTypes;
-import com.github.wrdlbrnft.simplejson.models.MappedValue;
+import com.github.wrdlbrnft.simplejson.builder.implementation.MappedValue;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/parser/InternalParserBuilder.java
+++ b/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/parser/InternalParserBuilder.java
@@ -10,8 +10,8 @@ import com.github.wrdlbrnft.codebuilder.variables.Field;
 import com.github.wrdlbrnft.simplejson.SimpleJsonTypes;
 import com.github.wrdlbrnft.simplejson.builder.ParserBuilder;
 import com.github.wrdlbrnft.simplejson.builder.parser.resolver.ElementParserResolver;
-import com.github.wrdlbrnft.simplejson.models.ImplementationResult;
-import com.github.wrdlbrnft.simplejson.models.MappedValue;
+import com.github.wrdlbrnft.simplejson.builder.implementation.ImplementationResult;
+import com.github.wrdlbrnft.simplejson.builder.implementation.MappedValue;
 
 import java.util.EnumSet;
 import java.util.List;

--- a/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/parser/ToJsonObjectBuilder.java
+++ b/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/parser/ToJsonObjectBuilder.java
@@ -6,7 +6,7 @@ import com.github.wrdlbrnft.codebuilder.types.Types;
 import com.github.wrdlbrnft.codebuilder.variables.Variable;
 import com.github.wrdlbrnft.codebuilder.variables.Variables;
 import com.github.wrdlbrnft.simplejson.SimpleJsonTypes;
-import com.github.wrdlbrnft.simplejson.models.MappedValue;
+import com.github.wrdlbrnft.simplejson.builder.implementation.MappedValue;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/parser/resolver/BaseParserEntry.java
+++ b/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/parser/resolver/BaseParserEntry.java
@@ -4,13 +4,12 @@ import com.github.wrdlbrnft.codebuilder.code.CodeElement;
 import com.github.wrdlbrnft.codebuilder.types.Type;
 import com.github.wrdlbrnft.codebuilder.variables.Field;
 import com.github.wrdlbrnft.simplejson.builder.ParserBuilder;
-import com.github.wrdlbrnft.simplejson.models.MappedValue;
+import com.github.wrdlbrnft.simplejson.builder.implementation.MappedValue;
 
 import java.util.EnumSet;
 
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.Modifier;
-import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeMirror;
 
 /**

--- a/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/parser/resolver/BooleanParserEntry.java
+++ b/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/parser/resolver/BooleanParserEntry.java
@@ -5,7 +5,7 @@ import com.github.wrdlbrnft.codebuilder.util.Utils;
 import com.github.wrdlbrnft.codebuilder.variables.Field;
 import com.github.wrdlbrnft.simplejson.SimpleJsonTypes;
 import com.github.wrdlbrnft.simplejson.builder.ParserBuilder;
-import com.github.wrdlbrnft.simplejson.models.MappedValue;
+import com.github.wrdlbrnft.simplejson.builder.implementation.MappedValue;
 
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.type.TypeMirror;

--- a/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/parser/resolver/CalendarParserEntry.java
+++ b/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/parser/resolver/CalendarParserEntry.java
@@ -7,7 +7,7 @@ import com.github.wrdlbrnft.codebuilder.variables.Field;
 import com.github.wrdlbrnft.simplejson.SimpleJsonAnnotations;
 import com.github.wrdlbrnft.simplejson.SimpleJsonTypes;
 import com.github.wrdlbrnft.simplejson.builder.ParserBuilder;
-import com.github.wrdlbrnft.simplejson.models.MappedValue;
+import com.github.wrdlbrnft.simplejson.builder.implementation.MappedValue;
 
 import java.util.Calendar;
 

--- a/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/parser/resolver/CustomParserEntry.java
+++ b/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/parser/resolver/CustomParserEntry.java
@@ -1,17 +1,16 @@
 package com.github.wrdlbrnft.simplejson.builder.parser.resolver;
 
 import com.github.wrdlbrnft.codebuilder.types.Types;
-import com.github.wrdlbrnft.codebuilder.util.Utils;
 import com.github.wrdlbrnft.codebuilder.variables.Field;
+import com.github.wrdlbrnft.simplejson.SimpleJsonAnnotations;
 import com.github.wrdlbrnft.simplejson.SimpleJsonTypes;
 import com.github.wrdlbrnft.simplejson.builder.ParserBuilder;
-import com.github.wrdlbrnft.simplejson.models.MappedValue;
-import com.github.wrdlbrnft.simplejson.SimpleJsonAnnotations;
+import com.github.wrdlbrnft.simplejson.builder.implementation.MappedValue;
 import com.github.wrdlbrnft.simplejson.builder.implementation.MethodPairInfo;
 
 import javax.annotation.processing.ProcessingEnvironment;
-import javax.lang.model.type.TypeMirror;
 import javax.lang.model.element.AnnotationValue;
+import javax.lang.model.type.TypeMirror;
 
 /**
  * Created with Android Studio<br>

--- a/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/parser/resolver/DateParserEntry.java
+++ b/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/parser/resolver/DateParserEntry.java
@@ -7,7 +7,7 @@ import com.github.wrdlbrnft.codebuilder.variables.Field;
 import com.github.wrdlbrnft.simplejson.SimpleJsonAnnotations;
 import com.github.wrdlbrnft.simplejson.SimpleJsonTypes;
 import com.github.wrdlbrnft.simplejson.builder.ParserBuilder;
-import com.github.wrdlbrnft.simplejson.models.MappedValue;
+import com.github.wrdlbrnft.simplejson.builder.implementation.MappedValue;
 
 import java.util.Date;
 

--- a/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/parser/resolver/DoubleParserEntry.java
+++ b/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/parser/resolver/DoubleParserEntry.java
@@ -5,7 +5,7 @@ import com.github.wrdlbrnft.codebuilder.util.Utils;
 import com.github.wrdlbrnft.codebuilder.variables.Field;
 import com.github.wrdlbrnft.simplejson.SimpleJsonTypes;
 import com.github.wrdlbrnft.simplejson.builder.ParserBuilder;
-import com.github.wrdlbrnft.simplejson.models.MappedValue;
+import com.github.wrdlbrnft.simplejson.builder.implementation.MappedValue;
 
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.type.TypeMirror;

--- a/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/parser/resolver/ElementParserResolver.java
+++ b/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/parser/resolver/ElementParserResolver.java
@@ -9,7 +9,7 @@ import com.github.wrdlbrnft.simplejson.SimpleJsonAnnotations;
 import com.github.wrdlbrnft.simplejson.SimpleJsonTypes;
 import com.github.wrdlbrnft.simplejson.builder.ParserBuilder;
 import com.github.wrdlbrnft.simplejson.builder.implementation.MethodPairInfo;
-import com.github.wrdlbrnft.simplejson.models.MappedValue;
+import com.github.wrdlbrnft.simplejson.builder.implementation.MappedValue;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/parser/resolver/EnumParserEntry.java
+++ b/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/parser/resolver/EnumParserEntry.java
@@ -6,7 +6,7 @@ import com.github.wrdlbrnft.codebuilder.variables.Field;
 import com.github.wrdlbrnft.simplejson.SimpleJsonAnnotations;
 import com.github.wrdlbrnft.simplejson.SimpleJsonTypes;
 import com.github.wrdlbrnft.simplejson.builder.ParserBuilder;
-import com.github.wrdlbrnft.simplejson.models.MappedValue;
+import com.github.wrdlbrnft.simplejson.builder.implementation.MappedValue;
 
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.TypeElement;

--- a/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/parser/resolver/FloatParserEntry.java
+++ b/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/parser/resolver/FloatParserEntry.java
@@ -5,7 +5,7 @@ import com.github.wrdlbrnft.codebuilder.util.Utils;
 import com.github.wrdlbrnft.codebuilder.variables.Field;
 import com.github.wrdlbrnft.simplejson.SimpleJsonTypes;
 import com.github.wrdlbrnft.simplejson.builder.ParserBuilder;
-import com.github.wrdlbrnft.simplejson.models.MappedValue;
+import com.github.wrdlbrnft.simplejson.builder.implementation.MappedValue;
 
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.type.TypeMirror;

--- a/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/parser/resolver/IntegerParserEntry.java
+++ b/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/parser/resolver/IntegerParserEntry.java
@@ -5,7 +5,7 @@ import com.github.wrdlbrnft.codebuilder.util.Utils;
 import com.github.wrdlbrnft.codebuilder.variables.Field;
 import com.github.wrdlbrnft.simplejson.SimpleJsonTypes;
 import com.github.wrdlbrnft.simplejson.builder.ParserBuilder;
-import com.github.wrdlbrnft.simplejson.models.MappedValue;
+import com.github.wrdlbrnft.simplejson.builder.implementation.MappedValue;
 
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.type.TypeMirror;

--- a/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/parser/resolver/JsonEntityParserEntry.java
+++ b/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/parser/resolver/JsonEntityParserEntry.java
@@ -6,7 +6,7 @@ import com.github.wrdlbrnft.codebuilder.variables.Field;
 import com.github.wrdlbrnft.simplejson.SimpleJsonAnnotations;
 import com.github.wrdlbrnft.simplejson.SimpleJsonTypes;
 import com.github.wrdlbrnft.simplejson.builder.ParserBuilder;
-import com.github.wrdlbrnft.simplejson.models.MappedValue;
+import com.github.wrdlbrnft.simplejson.builder.implementation.MappedValue;
 
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.TypeElement;

--- a/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/parser/resolver/LongParserEntry.java
+++ b/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/parser/resolver/LongParserEntry.java
@@ -5,7 +5,7 @@ import com.github.wrdlbrnft.codebuilder.util.Utils;
 import com.github.wrdlbrnft.codebuilder.variables.Field;
 import com.github.wrdlbrnft.simplejson.SimpleJsonTypes;
 import com.github.wrdlbrnft.simplejson.builder.ParserBuilder;
-import com.github.wrdlbrnft.simplejson.models.MappedValue;
+import com.github.wrdlbrnft.simplejson.builder.implementation.MappedValue;
 
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.type.TypeMirror;

--- a/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/parser/resolver/StringParserEntry.java
+++ b/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/builder/parser/resolver/StringParserEntry.java
@@ -5,7 +5,7 @@ import com.github.wrdlbrnft.codebuilder.util.Utils;
 import com.github.wrdlbrnft.codebuilder.variables.Field;
 import com.github.wrdlbrnft.simplejson.SimpleJsonTypes;
 import com.github.wrdlbrnft.simplejson.builder.ParserBuilder;
-import com.github.wrdlbrnft.simplejson.models.MappedValue;
+import com.github.wrdlbrnft.simplejson.builder.implementation.MappedValue;
 
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.type.TypeMirror;

--- a/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/utils/ParameterUtils.java
+++ b/SimpleJsonProcessor/src/main/java/com/github/wrdlbrnft/simplejson/utils/ParameterUtils.java
@@ -8,7 +8,8 @@ import com.github.wrdlbrnft.codebuilder.executables.Methods;
 import com.github.wrdlbrnft.codebuilder.types.Type;
 import com.github.wrdlbrnft.codebuilder.types.Types;
 import com.github.wrdlbrnft.codebuilder.util.Utils;
-import com.github.wrdlbrnft.simplejson.models.MappedValue;
+import com.github.wrdlbrnft.simplejson.builder.implementation.ImplementationInfo;
+import com.github.wrdlbrnft.simplejson.builder.implementation.MappedValue;
 
 import java.util.Arrays;
 import java.util.List;
@@ -40,16 +41,20 @@ public class ParameterUtils {
         return name;
     }
 
-    public static CodeElement handleOptionalParameter(MappedValue value, CodeElement parameter) {
+    public static CodeElement handleOptionalParameter(ImplementationInfo info, MappedValue value, CodeElement parameter) {
         final String groupName = value.getMethodPairInfo().getGroupName();
 
         if (value.getValueType() == MappedValue.ValueType.VALUE && Utils.isPrimitive(value.getItemType())) {
             return parameter;
         }
 
-        final Value nullErrorMessage = Values.of(groupName + " is not optional, you have to set a non null value for it.");
-        return value.isOptional()
-                ? parameter
-                : METHOD_REQUIRE_NON_NULL.callOnTarget(TYPE_OBJECTS, parameter, nullErrorMessage);
+        if (info.isStrict()) {
+            final Value nullErrorMessage = Values.of(groupName + " is not optional, you have to set a non null value for it.");
+            return value.isOptional()
+                    ? parameter
+                    : METHOD_REQUIRE_NON_NULL.callOnTarget(TYPE_OBJECTS, parameter, nullErrorMessage);
+        }
+
+        return parameter;
     }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,8 +11,8 @@
 Just add is these two dependencies to your build.gradle file:
 
 ```groovy
-implementation 'com.github.wrdlbrnft:simple-json:0.3.0.35'
-annotationProcessor 'com.github.wrdlbrnft:simple-json-processor:0.3.0.35'
+implementation 'com.github.wrdlbrnft:simple-json:0.3.0.53'
+annotationProcessor 'com.github.wrdlbrnft:simple-json-processor:0.3.0.53'
 ```
 
 ## Basic Usage


### PR DESCRIPTION
Strict mode (which enforces non null values for all mandatory fields) can now be switched on and off per entity. It is now also off by default. Parsing of json is unaffected by strict mode - all mandatory fields still have to be present. Also includes some minor refactoring here and there.

Strict mode can be enabled for an entity like this:
```java
@JsonEntity(strict = true)
public interface ExampleModel {
   ...
}
```